### PR TITLE
fix: resolve TypeScript compilation errors

### DIFF
--- a/src/builder/pipeline.ts
+++ b/src/builder/pipeline.ts
@@ -76,7 +76,7 @@ export async function runBuilderPipeline(
     { session_id: session.id, metric_name: 'memories_retrieved_count', metric_value: context.memoriesRetrieved },
     { session_id: session.id, metric_name: 'files_included_count', metric_value: context.filesIncluded.length },
   ];
-  supabase.from('builder_metrics').insert(metricsToInsert).then().catch(() => {});
+  supabase.from('builder_metrics').insert(metricsToInsert).then(undefined, () => {});
 
   // 12. Retrieval relevance scoring (every 50th request, fire-and-forget)
   if (context.retrievedMemoryDetails.length > 0 && session.messageCount % 50 === 0) {

--- a/src/services/embeddingService.ts
+++ b/src/services/embeddingService.ts
@@ -20,7 +20,7 @@ export async function generateEmbedding(
     throw new Error(`Voyage embedding API error: ${response.status}`);
   }
 
-  const data = await response.json();
+  const data = await response.json() as { data: Array<{ embedding: number[] }> };
   return data.data[0].embedding;
 }
 


### PR DESCRIPTION
Fixes two TypeScript errors reported in issue #12:

- `pipeline.ts:79`: Replace `.then().catch()` with `.then(undefined, () => {})` since Supabase returns `PromiseLike` which lacks a `.catch()` method
- `embeddingService.ts:24`: Add type assertion for `response.json()` result since TypeScript treats it as `unknown` in strict mode

Closes #12

Generated with [Claude Code](https://claude.ai/code)