### PR TITLE
feat: implement app creation spec

### DIFF
--- a/src/builder/pipeline.ts
+++ b/src/builder/pipeline.ts
@@ -45,6 +45,13 @@ export async function runBuilderPipeline(
   // 7. Store assistant message
   await storeMessage(session.id, 'assistant', parsed.conversationText, parsed.codeUpdate, llmResponse.usage);
 
+  // 7b. Update app's last_edited_at (non-critical)
+  supabase
+    .from('creator_apps')
+    .update({ last_edited_at: new Date().toISOString() })
+    .eq('app_id', appId)
+    .catch(() => {});
+
   // 8. Update session code state
   if (parsed.codeUpdate?.files) {
     const updatedCode = { ...session.currentCode, ...parsed.codeUpdate.files };

--- a/src/routes/builder.ts
+++ b/src/routes/builder.ts
@@ -60,24 +60,150 @@ router.get('/usage', async (req: Request, res: Response) => {
   }
 });
 
-// GET /builder/apps
+// POST /builder/apps — Create a new app
+router.post('/apps', async (req: Request, res: Response) => {
+  try {
+    const { userId } = (req as any).pelkoUser;
+    const { displayName } = req.body;
+
+    if (!displayName || !displayName.trim()) {
+      return res.status(400).json({ error: 'displayName is required' });
+    }
+
+    // Generate a URL-safe app_id from the display name
+    const baseId = displayName.trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .substring(0, 40);
+
+    // Check uniqueness, add random suffix if collision
+    const { data: existing } = await supabase
+      .from('creator_apps')
+      .select('app_id')
+      .eq('app_id', baseId)
+      .single();
+
+    const appId = existing
+      ? `${baseId}-${Math.random().toString(36).substring(2, 6)}`
+      : baseId;
+
+    // Create the app record
+    const { data: app, error } = await supabase
+      .from('creator_apps')
+      .insert({
+        pelko_user_id: userId,
+        app_id: appId,
+        display_name: displayName.trim(),
+        status: 'draft',
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return res.json({
+      appId: app.app_id,
+      displayName: app.display_name,
+      status: app.status,
+      createdAt: app.created_at,
+    });
+  } catch (err: any) {
+    console.error('Create app error:', err);
+    return res.status(500).json({ error: 'Failed to create app' });
+  }
+});
+
+// GET /builder/apps — List the creator's apps
 router.get('/apps', async (req: Request, res: Response) => {
   try {
     const { userId } = (req as any).pelkoUser;
+
+    // Get all non-archived apps for this user
+    const { data: apps, error } = await supabase
+      .from('creator_apps')
+      .select('*')
+      .eq('pelko_user_id', userId)
+      .neq('status', 'archived')
+      .order('last_edited_at', { ascending: false });
+
+    if (error) throw error;
+
+    // Get session info (message counts) for each app
+    const appIds = (apps || []).map(a => a.app_id);
     const { data: sessions } = await supabase
       .from('builder_sessions')
-      .select('app_id, message_count, started_at, last_active_at')
+      .select('app_id, message_count, last_active_at')
       .eq('user_id', userId)
-      .order('last_active_at', { ascending: false });
+      .in('app_id', appIds);
+
+    const sessionMap = new Map(
+      (sessions || []).map(s => [s.app_id, s])
+    );
 
     return res.json({
-      apps: (sessions || []).map(s => ({
-        appId: s.app_id, messageCount: s.message_count,
-        startedAt: s.started_at, lastActiveAt: s.last_active_at,
+      apps: (apps || []).map(app => ({
+        appId: app.app_id,
+        displayName: app.display_name,
+        status: app.status,
+        iconUrl: app.icon_url,
+        createdAt: app.created_at,
+        lastEditedAt: app.last_edited_at,
+        messageCount: sessionMap.get(app.app_id)?.message_count || 0,
       })),
     });
   } catch (err: any) {
+    console.error('Apps list error:', err);
     return res.status(500).json({ error: 'Failed to fetch apps' });
+  }
+});
+
+// PATCH /builder/apps/:appId — Rename an app or change its status
+router.patch('/apps/:appId', async (req: Request, res: Response) => {
+  try {
+    const { userId } = (req as any).pelkoUser;
+    const { appId } = req.params;
+    const { displayName, status } = req.body;
+
+    // Verify ownership
+    const { data: existing } = await supabase
+      .from('creator_apps')
+      .select('id')
+      .eq('app_id', appId)
+      .eq('pelko_user_id', userId)
+      .single();
+
+    if (!existing) {
+      return res.status(404).json({ error: 'App not found' });
+    }
+
+    const updates: Record<string, any> = {
+      last_edited_at: new Date().toISOString(),
+    };
+    if (displayName && displayName.trim()) {
+      updates.display_name = displayName.trim();
+    }
+    if (status && ['draft', 'live', 'paused', 'archived'].includes(status)) {
+      updates.status = status;
+    }
+
+    const { data: updated, error } = await supabase
+      .from('creator_apps')
+      .update(updates)
+      .eq('id', existing.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return res.json({
+      appId: updated.app_id,
+      displayName: updated.display_name,
+      status: updated.status,
+    });
+  } catch (err: any) {
+    console.error('Update app error:', err);
+    return res.status(500).json({ error: 'Failed to update app' });
   }
 });
 


### PR DESCRIPTION
Implements the backend portion of the app creation spec from #11:

- Replace `GET /builder/apps` to read from creator_apps table with session join
- Add `POST /builder/apps` for creating new apps with URL-safe app_id generation
- Add `PATCH /builder/apps/:appId` for renaming apps or changing their status
- Update runBuilderPipeline to fire-and-forget update last_edited_at on creator_apps

Closes #11

Generated with [Claude Code](https://claude.ai/code)